### PR TITLE
Fix SPNAV_EVENT_MOTION comparison with maxval

### DIFF
--- a/src/ui.cc
+++ b/src/ui.cc
@@ -325,7 +325,7 @@ void MainWin::spnav_input()
 		switch(ev.type) {
 		case SPNAV_EVENT_MOTION:
 			for(int i=0; i<6; i++) {
-				if(abs(ev.motion.data[i] > maxval)) maxval = abs(ev.motion.data[i]);
+				if(abs(ev.motion.data[i]) > maxval) maxval = abs(ev.motion.data[i]);
 			}
 			for(int i=0; i<6; i++) {
 				prog_axis[i]->setMinimum(-maxval);


### PR DESCRIPTION
Found by compiler with `-Wabsolute-value` - I don't know what the effect is but the intent of the code seems clear.
