### PR TITLE
Add a meson build file for Qt 6

### DIFF
--- a/.github/workflows/build_gnulinux_meson.yml
+++ b/.github/workflows/build_gnulinux_meson.yml
@@ -1,0 +1,47 @@
+name: GNU/Linux meson build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        lfs: true
+
+    - name: install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install ninja-build qt6-base-dev
+        git clone https://github.com/FreeSpacenav/libspnav
+        cd libspnav
+        ./configure
+        make
+        sudo make install
+
+    - name: install latest meson
+      # At least 0.63 required on Ubuntu 22.04 to find Qt 6
+      run: |
+        pipx install meson
+
+    - name: configure
+      run: meson setup _build
+
+    - name: build
+      run: meson compile -C _build
+
+    - name: stage install
+      run: DESTDIR=$GITHUB_WORKSPACE/spnavcfg-gnulinux-meson meson install -C _build
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: spnavcfg-gnulinux-meson
+        path: spnavcfg-gnulinux-meson
+
+# vi:ts=2 sts=2 sw=2 expandtab:

--- a/Makefile.in
+++ b/Makefile.in
@@ -28,9 +28,9 @@ $(bin): $(obj)
 -include $(dep)
 
 src/main.o: src/main.cc
-src/ui.o: src/ui.cc ui_mainwin.h ui_bnmaprow.h ui_about.h
+src/ui.o: src/ui.cc ui_spnavcfg.h ui_bnmaprow.h ui_about.h
 
-ui_mainwin.h: ui/spnavcfg.ui
+ui_spnavcfg.h: ui/spnavcfg.ui
 	$(UIC) -o $@ $<
 
 ui_bnmaprow.h: ui/bnmaprow.ui
@@ -47,7 +47,7 @@ res.cc: ui/spnavcfg.qrc icons/devices.png
 
 .PHONY: clean
 clean:
-	rm -f $(obj) $(bin) $(mocsrc) ui_mainwin.h ui_bnmaprow.h ui_about.h res.cc
+	rm -f $(obj) $(bin) $(mocsrc) ui_spnavcfg.h ui_bnmaprow.h ui_about.h res.cc
 
 .PHONY: cleandep
 cleandep:

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,42 @@
+project('spnavcfg', ['c', 'cpp'],
+  default_options: ['warning_level=3', 'cpp_std=c++17'],
+  meson_version : '>=0.63.0',
+)
+
+qt6 = import('qt6')
+
+qt6modules = dependency('qt6', modules: ['Core', 'Gui', 'Widgets'])
+libspnav = dependency('spnav', version: '>1.1')
+libx11 = dependency('x11')
+
+moc_ui = qt6.compile_moc(headers: ['src/ui.h'])
+ui_headers = qt6.compile_ui(
+  sources: ['ui/about.ui', 'ui/bnmaprow.ui', 'ui/spnavcfg.ui']
+)
+resources = qt6.compile_resources(sources: ['ui/spnavcfg.qrc'])
+
+executable('spnavcfg',
+    sources: [
+      'src/main.cc',
+      'src/spnavcfg.c',
+      'src/ui.cc',
+      moc_ui,
+      ui_headers,
+      resources,
+    ],
+    dependencies: [qt6modules, libspnav, libx11],
+    install: true,
+)
+
+datadir = get_option('datadir')
+
+foreach icon_size: ['48x48', '128x128', '256x256']
+  install_data('icons/spnavcfg-@0@.png'.format(icon_size),
+    rename: 'spnavcfg.png',
+    install_dir: datadir / 'icons/hicolor' / icon_size / 'apps',
+  )
+endforeach
+
+install_data('icons/spnavcfg.desktop',
+  install_dir: datadir / 'applications',
+)

--- a/src/ui.cc
+++ b/src/ui.cc
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <spnav.h>
 #include "ui.h"
 #include "spnavcfg.h"
-#include "ui_mainwin.h"
+#include "ui_spnavcfg.h"
 #include "ui_bnmaprow.h"
 #include "ui_about.h"
 #include <QMessageBox>


### PR DESCRIPTION
pkg-config files are not provided for Qt 6 on macOS or Ubuntu 22.04:
https://bugreports.qt.io/browse/QTBUG-86080

C++17 is required.

It is not possible to set the output header filename with compile_ui().

---

I tried to do this in a way where it was just an extra file - didn't quite succeed as I couldn't find a way to  create `ui_mainwin.h`.
