### PR TITLE
Immediately expand wildcards

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,5 +1,5 @@
-csrc = $(wildcard src/*.c)
-ccsrc = $(wildcard src/*.cc)
+csrc := $(wildcard src/*.c)
+ccsrc := $(wildcard src/*.cc)
 mochdr = src/ui.h
 mocsrc = $(mochdr:.h=.moc.cc)
 obj = $(sort $(csrc:.c=.o) $(ccsrc:.cc=.o) $(mocsrc:.cc=.o)) res.cc


### PR DESCRIPTION
If wildcards are expanded later, a duplicate of ui.moc.o can be added to the link command-line, which will fail with some linkers due to duplicate symbols.