### PR TITLE
Use libxkbcommon instead of libX11

### DIFF
--- a/.github/workflows/build_gnulinux.yml
+++ b/.github/workflows/build_gnulinux.yml
@@ -57,6 +57,7 @@ jobs:
           [[ "${QT_MAJOR_VERSION}" == 6 ]]  # i.e. assert
           sudo apt-get install qt6-base-dev
         fi
+        sudo apt-get install libxkbcommon-dev
 
     - name: install dependency Clang 19
       if: "${{ matrix.cc == 'clang-19' }}"

--- a/.github/workflows/build_macosx.yml
+++ b/.github/workflows/build_macosx.yml
@@ -28,7 +28,7 @@ jobs:
         sudo make install
 
     - name: configure
-      run: CFLAGS=-I/usr/X11R6/include LDFLAGS=-L/usr/X11R6/lib ./configure
+      run: CFLAGS=-I/opt/homebrew/include LDFLAGS=-L/opt/homebrew/lib ./configure
 
     - name: build
       run: make

--- a/.github/workflows/build_macosx.yml
+++ b/.github/workflows/build_macosx.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: install dependencies
       run: |
-        brew install xquartz libx11 qt@5 pkg-config
+        brew install xquartz libxkbcommon qt@5 pkg-config
         brew link qt@5 --force
         git clone --depth 1 https://github.com/FreeSpacenav/libspnav
         cd libspnav

--- a/Makefile.in
+++ b/Makefile.in
@@ -19,7 +19,7 @@ libpath = -L$(PREFIX)/lib
 CFLAGS = $(warn) $(dbg) $(opt) $(incpath) -fPIC $(add_cflags) -MMD
 CXXFLAGS = $(warn) $(dbg) $(opt) $(incpath) -fPIC $(cflags_qt) \
 		 $(add_cflags) -MMD
-LDFLAGS = $(libpath) $(libs_qt) -lspnav -lX11 $(add_ldflags)
+LDFLAGS = $(libpath) $(libs_qt) -lspnav -lxkbcommon $(add_ldflags)
 
 $(bin): $(obj)
 	$(CXX) -o $@ $(obj) $(LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Installation
 ------------
 First make sure you have the dependencies installed:
   - libspnav v1.0 or higher
+  - libxkbcommon
   - Qt 5 or Qt 6 (core, gui, and widgets)
 
 To build just run `./configure`, `make`, and `make install` as usual.

--- a/src/ui.cc
+++ b/src/ui.cc
@@ -26,7 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui_about.h"
 #include <QMessageBox>
 
-#include <X11/Xlib.h>
+#include <xkbcommon/xkbcommon.h>
 
 static QSlider *slider_sens_axis[6];
 static QCheckBox *chk_inv[6];
@@ -290,8 +290,8 @@ void MainWin::updateui()
 			bnrow[i].rad_action->setChecked(true);
 		}
 
-		char *str;
-		if(cfg.kbmap[i] > 0 && (str = XKeysymToString(cfg.kbmap[i]))) {
+		char str[64];
+		if(cfg.kbmap[i] > 0 && xkb_keysym_get_name(cfg.kbmap[i], str, sizeof str)) {
 			bnrow[i].rad_mapkey->setChecked(true);
 			bnrow[i].cmb_mapkey->setCurrentText(str);
 		}
@@ -640,8 +640,8 @@ void MainWin::combo_str_changed(const QString &qstr)
 			if(!str || !*str) return;
 
 			QLineEdit *ed = bnrow[i].cmb_mapkey->lineEdit();
-			KeySym sym = XStringToKeysym(str);
-			if(sym == NoSymbol) {
+			xkb_keysym_t sym = xkb_keysym_from_name(str, XKB_KEYSYM_NO_FLAGS);
+			if(sym == XKB_KEY_NoSymbol) {
 				QPalette cmap = def_cmb_cmap;
 				cmap.setColor(QPalette::Text, Qt::red);
 				ed->setPalette(cmap);


### PR DESCRIPTION
I was thinking about how to make libX11 optional as with the other Spacenav components but seeing how it was used swapping for libxkbcommon seemed simpler.

libxkbcommon is a Qt dependency.

This compiles and runs for me - although using Wayland I can't fully test it.

The `XKB_KEYSYM_NO_FLAGS` is the only bit of configuration:
https://xkbcommon.org/doc/current/group__keysyms.html#gadf335e065050f306ff9094aefa6c9736